### PR TITLE
Refactor/phase1.1 fixes

### DIFF
--- a/aibugbench/util/__init__.py
+++ b/aibugbench/util/__init__.py
@@ -1,0 +1,17 @@
+"""Utility helpers (extracted from legacy code).
+
+Currently provides:
+* unicode_safety
+* gitmeta
+"""
+
+from __future__ import annotations
+
+from .gitmeta import resolve_git_commit
+from .unicode_safety import is_unicode_safe, safe_print
+
+__all__ = [
+    "is_unicode_safe",
+    "resolve_git_commit",
+    "safe_print",
+]

--- a/aibugbench/util/gitmeta.py
+++ b/aibugbench/util/gitmeta.py
@@ -1,0 +1,44 @@
+"""Lightweight git metadata helper extracted from legacy code."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import subprocess
+
+__all__ = ["resolve_git_commit"]
+
+
+def _run_git(args: list[str], cwd: Path | None = None) -> str | None:
+    """Run a safe, fixed git subcommand and return stripped stdout or None.
+
+    Security considerations:
+    - Command is always the literal executable "git" plus caller-provided *args*.
+      The caller controls *args* but only with trusted internal usage (no user
+      input passes through unvalidated in current code paths).
+    - We do not use shell=True.
+    - Justify ignores: S603 (subprocess use) and S607 (partial path) — relying
+      on PATH resolution for standard developer tooling (git) is acceptable in
+      this context.
+    """
+    try:
+        git_exe = shutil.which("git")
+        if not git_exe:
+            return None
+        result = subprocess.run(  # noqa: S603
+            [git_exe, *args],
+            cwd=str(cwd) if cwd else None,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:  # pragma: no cover - git may be absent
+        return None
+    return None
+
+
+def resolve_git_commit(repo_root: Path | None = None) -> str | None:
+    """Return short commit hash for the repository at *repo_root* (or cwd)."""
+    return _run_git(["rev-parse", "--short", "HEAD"], cwd=repo_root)

--- a/aibugbench/util/unicode_safety.py
+++ b/aibugbench/util/unicode_safety.py
@@ -1,0 +1,61 @@
+"""Unicode / TTY helpers extracted from legacy code.
+
+Only lightweight standard-library code is used so this file has *no* external
+runtime dependencies.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TextIO
+
+__all__ = [
+    "is_unicode_safe",
+    "safe_print",
+]
+
+
+def is_unicode_safe(stream: TextIO | None = None) -> bool:
+    """Return *True* if *stream* is capable of rendering Unicode safely.
+
+    The logic mirrors the previous ad-hoc checks scattered in legacy files:
+    1. If the stream is not a tty ``isatty()`` -> assume safe (redirected to
+       file or pipe).
+    2. On Windows, we rely on UTF-8 mode (code page 65001) or *utf-8* encoding
+       on the text wrapper.
+    3. Otherwise, check that encoding contains *utf*.
+    """
+    stream = stream or sys.stdout
+
+    try:
+        if not stream.isatty():
+            return True
+    except Exception:  # pragma: no cover - safety
+        return True
+
+    enc = (stream.encoding or "").lower()
+    if "utf" in enc:
+        return True
+
+    if sys.platform.startswith("win"):
+        # Code page 65001 is UTF-8 on modern Windows terminals.
+        try:
+            import ctypes  # pragma: no cover - Windows-only
+
+            windll = getattr(ctypes, "windll", None)
+            if windll is not None and hasattr(windll, "kernel32"):
+                get_cp = getattr(windll.kernel32, "GetConsoleOutputCP", None)
+                if callable(get_cp):
+                    cp = int(get_cp())
+                    return cp == 65001
+        except Exception:  # pragma: no cover
+            return False
+    return False  # Non-Windows or Windows without UTF-8 code page
+
+
+def safe_print(message: str, *, ascii_replace: bool = True, stream: TextIO | None = None) -> None:
+    """Print *message* with fallback replacement if Unicode is unsafe."""
+    stream = stream or sys.stdout
+    if ascii_replace and not is_unicode_safe(stream):
+        message = message.encode("ascii", "replace").decode("ascii")
+    print(message, file=stream)

--- a/validation/repo_audit_enhanced.py
+++ b/validation/repo_audit_enhanced.py
@@ -47,6 +47,8 @@ import subprocess
 import sys
 from typing import Any, TypedDict, cast
 
+from aibugbench.io.fs import read_text  # shared helper; replaces local duplicate
+
 try:
     import tomllib  # py311+
 except Exception:  # pragma: no cover - optional
@@ -131,13 +133,6 @@ REQUESTS_CALL_RE = re.compile(r"\brequests\.(get|post|patch|put|delete|head|opti
 
 logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
 log = logging.getLogger("repo_audit")
-
-
-def read_text(p: Path) -> str:
-    try:
-        return p.read_text(encoding="utf-8", errors="replace")
-    except Exception:  # pragma: no cover - IO fallback
-        return ""
 
 
 def safe_yaml_load(text: str) -> Any:


### PR DESCRIPTION
# Utility step finished from phase 1

Added aibugbench/util/
– unicode_safety.py
 (is_unicode_safe , safe_print)

– gitmeta.py
 (resolve_git_commit)
– init.py re-exports the helpers.

Replaced the duplicate read_text in  validation/repo_audit_enhanced.py with the shared helper.